### PR TITLE
Feature/xdebug improvements

### DIFF
--- a/php72-apache2-node14-composer2/Dockerfile
+++ b/php72-apache2-node14-composer2/Dockerfile
@@ -5,5 +5,5 @@ RUN apt update && apt -y install git unzip
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash
 RUN nvm install 14
 RUN npm install -g yarn
-RUN pecl install xdebug-2.9.0 && docker-php-ext-enable xdebug
+RUN pecl install xdebug-3.1.6 && docker-php-ext-enable xdebug
 COPY ./conf/xdebug.ini /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini

--- a/php72-apache2-node14-composer2/conf/xdebug.ini
+++ b/php72-apache2-node14-composer2/conf/xdebug.ini
@@ -1,3 +1,5 @@
 xdebug.mode = debug
 xdebug.discover_client_host = true
 xdebug.idekey = PHPSTORM
+debug.client_host=host.docker.internal
+xdebug.client_port=9003

--- a/php72-apache2-node16-composer2/Dockerfile
+++ b/php72-apache2-node16-composer2/Dockerfile
@@ -5,7 +5,7 @@ COPY --from=node:16-slim /usr/local/lib/node_modules /usr/local/lib/node_modules
 SHELL ["/bin/bash", "--login", "-c"]
 RUN apt update && apt -y install git unzip
 RUN npm install -g yarn --force
-RUN pecl install xdebug-2.9.0 && docker-php-ext-enable xdebug
+RUN pecl install xdebug-3.1.6 && docker-php-ext-enable xdebug
 COPY ./conf/xdebug.ini /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 RUN apt autoremove -y && apt clean && apt autoclean && rm -rf /var/lib/apt/lists/*
 COPY ./conf/xdebug.ini /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini

--- a/php72-apache2-node16-composer2/conf/xdebug.ini
+++ b/php72-apache2-node16-composer2/conf/xdebug.ini
@@ -1,3 +1,5 @@
 xdebug.mode = debug
 xdebug.discover_client_host = true
 xdebug.idekey = PHPSTORM
+debug.client_host=host.docker.internal
+xdebug.client_port=9003

--- a/php82-apache2-node14-composer2/conf/xdebug.ini
+++ b/php82-apache2-node14-composer2/conf/xdebug.ini
@@ -1,3 +1,5 @@
 xdebug.mode = debug
 xdebug.discover_client_host = true
 xdebug.idekey = PHPSTORM
+debug.client_host=host.docker.internal
+xdebug.client_port=9003

--- a/php82-apache2-node16-composer2/conf/xdebug.ini
+++ b/php82-apache2-node16-composer2/conf/xdebug.ini
@@ -1,3 +1,5 @@
 xdebug.mode = debug
 xdebug.discover_client_host = true
 xdebug.idekey = PHPSTORM
+debug.client_host=host.docker.internal
+xdebug.client_port=9003


### PR DESCRIPTION
This fixes two issues:

1) It uses xdebug 3.1.6 (the lates supported version on php72)
2) It adds some configuration to make xdebug work in a docker environment