### PR TITLE
Add cache to docker build action

### DIFF
--- a/.github/workflows/build-php72-apache2-node14-composer2.yaml
+++ b/.github/workflows/build-php72-apache2-node14-composer2.yaml
@@ -40,3 +40,5 @@ jobs:
           tags: |
             ghcr.io/openconext/openconext-basecontainers/php72-apache2-node14-composer2:latest
             ghcr.io/openconext/openconext-basecontainers/php72-apache2-node14-composer2:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/build-php72-apache2-node16-composer2.yaml
+++ b/.github/workflows/build-php72-apache2-node16-composer2.yaml
@@ -9,7 +9,6 @@ on:
   schedule:
     - cron: '0 7 * * *'
   workflow_dispatch:
-    
 
 jobs:
   build-push-php72:
@@ -42,3 +41,5 @@ jobs:
           tags: |
             ghcr.io/openconext/openconext-basecontainers/php72-apache2-node16-composer2:latest
             ghcr.io/openconext/openconext-basecontainers/php72-apache2-node16-composer2:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/build-php72-apache2.yaml
+++ b/.github/workflows/build-php72-apache2.yaml
@@ -40,3 +40,5 @@ jobs:
           tags: |
             ghcr.io/openconext/openconext-basecontainers/php72-apache2:latest
             ghcr.io/openconext/openconext-basecontainers/php72-apache2:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/build-php72-fpm-apache2.yaml
+++ b/.github/workflows/build-php72-fpm-apache2.yaml
@@ -40,3 +40,5 @@ jobs:
           tags: |
             ghcr.io/openconext/openconext-basecontainers/php72-fpm-apache2:latest
             ghcr.io/openconext/openconext-basecontainers/php72-fpm-apache2:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/build-php82-apache2-node14-composer2.yaml
+++ b/.github/workflows/build-php82-apache2-node14-composer2.yaml
@@ -40,3 +40,5 @@ jobs:
           tags: |
             ghcr.io/openconext/openconext-basecontainers/php82-apache2-node14-composer2:latest
             ghcr.io/openconext/openconext-basecontainers/php82-apache2-node14-composer2:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/build-php82-apache2-node16-composer2.yaml
+++ b/.github/workflows/build-php82-apache2-node16-composer2.yaml
@@ -41,3 +41,5 @@ jobs:
           tags: |
             ghcr.io/openconext/openconext-basecontainers/php82-apache2-node16-composer2:latest
             ghcr.io/openconext/openconext-basecontainers/php82-apache2-node16-composer2:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/build-php82-apache2.yaml
+++ b/.github/workflows/build-php82-apache2.yaml
@@ -40,3 +40,5 @@ jobs:
           tags: |
             ghcr.io/openconext/openconext-basecontainers/php82-apache2:latest
             ghcr.io/openconext/openconext-basecontainers/php82-apache2:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/build-php82-fpm-apache2.yaml
+++ b/.github/workflows/build-php82-fpm-apache2.yaml
@@ -40,3 +40,5 @@ jobs:
           tags: |
             ghcr.io/openconext/openconext-basecontainers/php82-fpm-apache2:latest
             ghcr.io/openconext/openconext-basecontainers/php82-fpm-apache2:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
Untested, but this could speed up the container-builds. Some of them now take 30-45 minutes without this caching