### PR TITLE
Install the GD PHP extension on php82-apache2

### DIFF
--- a/php82-apache2/Dockerfile
+++ b/php82-apache2/Dockerfile
@@ -12,12 +12,16 @@ RUN apt -y upgrade && apt -y dist-upgrade
 # Install the packages we need
 RUN apt install -y curl \
   libgmp-dev \
-  libicu-dev
+  libicu-dev \
+  libfreetype6-dev \
+  libjpeg62-turbo-dev \
+  libpng-dev
 
 # Install the PHP extensions we need
 RUN docker-php-ext-install gmp \
   opcache  \
-  intl
+  intl \
+  gd
 
 # Clean up
 RUN apt autoremove -y && apt clean && apt autoclean && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
I'd like to have (need) the GD extension enabled on all PHP 8.2 images. Would this adjustment be adequate? I doubt we need all the jpeg/png libraries.

Stepup-SelfService requires php-gd for its PDF generator to function correctly.

@danakim @quartje what are your thoughts?