### PR TITLE
Feature/php82 apache fixes

### DIFF
--- a/php82-apache2/Dockerfile
+++ b/php82-apache2/Dockerfile
@@ -3,24 +3,33 @@ FROM php:8.2-apache-bullseye
 # Do an initial clean up and general upgrade of the distribution
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt clean && apt autoclean && apt update
-RUN apt -y upgrade && apt -y dist-upgrade
 
 # Install the packages we need
 RUN apt install -y curl \
+  libpng16-16 \
+  libjpeg62-turbo \
+  libfreetype6 \
   libgmp-dev \
   libicu-dev \
   libfreetype6-dev \
   libjpeg62-turbo-dev \
-  libpng-dev
-
-# Install the PHP extensions we need
-RUN docker-php-ext-install gmp \
+  libpng-dev &&\
+  docker-php-ext-configure gd --with-freetype --with-jpeg &&\
+  docker-php-ext-install -j$(nproc) gmp \
   opcache  \
   intl \
   gd
 
 # Clean up
-RUN apt autoremove -y && apt clean && apt autoclean && rm -rf /var/lib/apt/lists/*
+RUN apt -y remove libgmp-dev \
+  libicu-dev \
+  libfreetype6-dev \
+  libjpeg62-turbo-dev \
+  libpng-dev && \
+  apt autoremove -y && \
+  apt clean && \
+  apt autoclean && \
+  rm -rf /var/lib/apt/lists/* 
 
 # Enable the Apache2 modules we need
 RUN a2enmod rewrite headers expires proxy_fcgi

--- a/php82-apache2/Dockerfile
+++ b/php82-apache2/Dockerfile
@@ -1,8 +1,4 @@
-FROM php:8.2.6-apache-bullseye
-
-# Copy the Composer PHAR from the Composer image into the PHP image
-COPY --from=composer:1.9.3 /usr/bin/composer /usr/bin/composer
-RUN chmod +x /usr/bin/composer
+FROM php:8.2-apache-bullseye
 
 # Do an initial clean up and general upgrade of the distribution
 ENV DEBIAN_FRONTEND noninteractive


### PR DESCRIPTION
Various fixes for the php82-apache container:

* Use FROM php:8.2-apache-bullseye instead of using a pinned 8.2.6 version (which will inevitably run behind)
* Remove composer 1. Not needed anywhere
* Remove the -dev packages after installing the extensions: These are not needed
* Follow the official php docker manual for installing the gd extension. Will also configure freetype and jpeg correctly