### PR TITLE
Add the CSP headers if they are set as an env variable at startup

### DIFF
--- a/apache2/Dockerfile
+++ b/apache2/Dockerfile
@@ -16,6 +16,7 @@ RUN apt autoremove -y && apt clean && apt autoclean && rm -rf /var/lib/apt/lists
 RUN a2enmod authz_groupfile \
     xml2enc \
     headers \
+    ssl \
     proxy \
     proxy_connect \
     proxy_http \

--- a/apache2/Dockerfile
+++ b/apache2/Dockerfile
@@ -25,6 +25,7 @@ RUN a2enmod authz_groupfile \
 # Copy the default apache config
 COPY ./conf/apache2.conf /etc/apache2/apache2.conf
 COPY ./conf/security.conf /etc/apache2/conf-available/security.conf
+COPY ./conf/default-vhost.conf /etc/apache2/sites-available/000-default.conf
 
 # Copy the startup script
 COPY ./bin/start.sh /usr/local/bin/start.sh

--- a/apache2/Dockerfile
+++ b/apache2/Dockerfile
@@ -23,7 +23,7 @@ RUN a2enmod authz_groupfile \
 
 # Copy the default apache config
 COPY ./conf/apache2.conf /etc/apache2/apache2.conf
-COPY ./conf/security.conf /etc/apache2/security.conf
+COPY ./conf/security.conf /etc/apache2/conf-available/security.conf
 
 # Copy the startup script
 COPY ./bin/start.sh /usr/local/bin/start.sh

--- a/apache2/bin/start.sh
+++ b/apache2/bin/start.sh
@@ -45,5 +45,10 @@ for dir in \
     chmod 1777 "$dir";
 done
 
+# Add the CSP policy header if it has been set in the environment
+if [[ -v HTTPD_CSP ]]; then
+    echo "Header always set Content-Security-Policy \"${HTTPD_CSP}\"" >> /etc/apache2/security.conf
+fi
+
 # Start Apache2
 apache2 -D FOREGROUND

--- a/apache2/bin/start.sh
+++ b/apache2/bin/start.sh
@@ -45,9 +45,10 @@ for dir in \
     chmod 1777 "$dir";
 done
 
-# Add the CSP policy header if it has been set in the environment
-if [[ -v HTTPD_CSP ]]; then
-    echo "Header always set Content-Security-Policy \"${HTTPD_CSP}\"" >> /etc/apache2/security.conf
+# If we do not define the HTTPD_CSP env var, let's set an empty one so
+# Apache stops complaining in the logs
+if [[ ! -v HTTPD_CSP ]]; then
+    export HTTPD_CSP=''
 fi
 
 # Start Apache2

--- a/apache2/conf/default-vhost.conf
+++ b/apache2/conf/default-vhost.conf
@@ -1,0 +1,34 @@
+<VirtualHost *:80>
+    # The ServerName directive sets the request scheme, hostname and port that
+    # the server uses to identify itself. This is used when creating
+    # redirection URLs. In the context of virtual hosts, the ServerName
+    # specifies what hostname must appear in the request's Host: header to
+    # match this virtual host. For the default virtual host (this file) this
+    # value is not decisive as it is used as a last resort host regardless.
+    # However, you must set it for any further virtual host explicitly.
+    #ServerName www.example.com
+
+    ServerAdmin webmaster@localhost
+    DocumentRoot /var/www/html
+
+    # Available loglevels: trace8, ..., trace1, debug, info, notice, warn,
+    # error, crit, alert, emerg.
+    # It is also possible to configure the loglevel for particular
+    # modules, e.g.
+    #LogLevel info ssl:warn
+
+    #ErrorLog ${APACHE_LOG_DIR}/error.log
+    #CustomLog ${APACHE_LOG_DIR}/access.log combined
+
+    ErrorLog /proc/self/fd/2
+    CustomLog /proc/self/fd/1 common
+
+    # For most configuration files from conf-available/, which are
+    # enabled or disabled at a global level, it is possible to
+    # include a line for only one particular virtual host. For example the
+    # following line enables the CGI configuration for this host only
+    # after it has been globally disabled with "a2disconf".
+    #Include conf-available/serve-cgi-bin.conf
+</VirtualHost>
+
+# vim: syntax=apache ts=4 sw=4 sts=4 sr noet

--- a/apache2/conf/security.conf
+++ b/apache2/conf/security.conf
@@ -74,4 +74,3 @@ RequestHeader unset Proxy early
 SSLRandomSeed startup builtin
 SSLRandomSeed connect builtin
 
-# vim: syntax=apache ts=4 sw=4 sts=4 sr noet

--- a/apache2/conf/security.conf
+++ b/apache2/conf/security.conf
@@ -71,6 +71,13 @@ TraceEnable Off
 
 RequestHeader unset Proxy early
 
-SSLRandomSeed startup builtin
-SSLRandomSeed connect builtin
+#SSLRandomSeed startup builtin
+#SSLRandomSeed connect builtin
 
+# Set the CSP header if it was defined as an env variable
+PassEnv HTTPD_CSP
+<If "osenv('HTTPD_CSP') != ''">
+    Header always set Content-Security-Policy "${HTTPD_CSP}"
+</If>
+
+# vim: syntax=apache ts=4 sw=4 sts=4 sr noet

--- a/apache2/conf/security.conf
+++ b/apache2/conf/security.conf
@@ -71,8 +71,8 @@ TraceEnable Off
 
 RequestHeader unset Proxy early
 
-#SSLRandomSeed startup builtin
-#SSLRandomSeed connect builtin
+SSLRandomSeed startup builtin
+SSLRandomSeed connect builtin
 
 # Set the CSP header if it was defined as an env variable
 PassEnv HTTPD_CSP


### PR DESCRIPTION
@quartje - I have tested this with the following command:

`docker run -p 8080:80 -e HTTPD_CSP="default-src; object-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; font-src 'self'; connect-src 'self'; img-src 'self' data:; form-action 'self'; base-uri 'none'" apache2:test` and it works, it adds the line to the config.

I think this is similar to what Ansible will add. 