### PR TITLE
Added an example Dockerfile using Debian

### DIFF
--- a/php72-apache2/Dockerfile.debian
+++ b/php72-apache2/Dockerfile.debian
@@ -1,0 +1,59 @@
+FROM debian:bullseye-slim
+
+RUN apt clean && apt autoclean && apt update
+
+# Install Apache2 and all other packages we need
+RUN apt install -y apache2 \
+    curl \
+    wget \
+    gnupg \
+    libpng16-16 \
+    libjpeg62-turbo \
+    libfreetype6 \
+    libgmp-dev \
+    libicu-dev \
+    libfreetype6-dev \
+    libjpeg62-turbo-dev \
+    libpng-dev \
+    lsb-release
+
+# Add the Sury PHP Repo and install PHP
+RUN echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list; \
+    wget -qO - https://packages.sury.org/php/apt.gpg | apt-key add -; \
+    apt update
+RUN apt install -y php7.2 \
+    php7.2-gd \
+    php7.2-mysql \
+    php7.2-opcache \
+    php7.2-intl \
+    php7.2-gmp \
+    php7.2-apcu \
+    php7.2-apcu-bc
+
+# Cleanup
+RUN apt -y remove libgmp-dev \
+  libicu-dev \
+  libfreetype6-dev \
+  libjpeg62-turbo-dev \
+  libpng-dev && \
+  apt autoremove -y && \
+  apt clean && \
+  apt autoclean && \
+  rm -rf /var/lib/apt/lists/*
+
+# Enable the Apache2 modules we need
+RUN a2enmod php7.2 rewrite headers expires proxy_fcgi
+
+# Set the default workdir
+WORKDIR /var/www/html
+
+# Copy the startup script
+COPY ./bin/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+# Default port to listen on
+EXPOSE 80
+
+# Start Apache
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["apache2-foreground"]

--- a/php82-apache2/Dockerfile.debian
+++ b/php82-apache2/Dockerfile.debian
@@ -1,0 +1,59 @@
+FROM debian:bullseye-slim
+
+RUN apt clean && apt autoclean && apt update
+
+# Install Apache2 and all other packages we need
+RUN apt install -y apache2 \
+    curl \
+    wget \
+    gnupg \
+    libpng16-16 \
+    libjpeg62-turbo \
+    libfreetype6 \
+    libgmp-dev \
+    libicu-dev \
+    libfreetype6-dev \
+    libjpeg62-turbo-dev \
+    libpng-dev \
+    lsb-release
+
+# Add the Sury PHP Repo and install PHP
+RUN echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list; \
+    wget -qO - https://packages.sury.org/php/apt.gpg | apt-key add -; \
+    apt update
+RUN apt install -y php8.2 \
+    php8.2-gd \
+    php8.2-mysql \
+    php8.2-opcache \
+    php8.2-intl \
+    php8.2-gmp \
+    php8.2-apcu \
+    php8.2-apcu-bc
+
+# Cleanup
+RUN apt -y remove libgmp-dev \
+  libicu-dev \
+  libfreetype6-dev \
+  libjpeg62-turbo-dev \
+  libpng-dev && \
+  apt autoremove -y && \
+  apt clean && \
+  apt autoclean && \
+  rm -rf /var/lib/apt/lists/*
+
+# Enable the Apache2 modules we need
+RUN a2enmod php8.2 rewrite headers expires proxy_fcgi
+
+# Set the default workdir
+WORKDIR /var/www/html
+
+# Copy the startup script
+COPY ./bin/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+# Default port to listen on
+EXPOSE 80
+
+# Start Apache
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["apache2-foreground"]


### PR DESCRIPTION
Hi @quartje ! When working on that ticket to remove gcc and other build tools from the images, we discussed the possibility of using plain Debian as a base for the php + apache images as well (like we do with the plain Apache2 images), as opposed to the official PHP image. 

I have opened this branch and PR with an example Dockerfile in each of the php-apache images that uses Debian as a base. The files are called `Dockerfile.debian`. You will see that they are not as different as you would expect. The big difference is that Debian comes by default with PHP 7.4. We need PHP 7.2 and 8.2 The semi-official - and recommended by Debian - way to install various other versions of PHP is by using the Sury repository: https://deb.sury.org/. Adding this repo to the OS not only allows us to install various versions of PHP but also install them in parallel if we ever need to.

I have successfully used this repo in a lot of other projects, never ran into issues and especially security issues. I will leave it to you to evaluate if you want to use it. My recommendation would be to switch to this:

* much easier to install and manage packages.
* a consistent way of installing packages: no more using custom scripts and Pecl at the same time. And consistent with the other base images
* no more build tools (gcc, gd) installed in the image
* have tested this and resulting image is much smaller: ~350 mb as opposed to ~650 mb like it is now
* you can install xdebug simply by running `apt-get install php7.2-xdebug`, no need to involve pecl in the mix