### PR TITLE
PHP82 and PHP72: Remove status module

### DIFF
--- a/php72-apache2/Dockerfile
+++ b/php72-apache2/Dockerfile
@@ -40,7 +40,8 @@ COPY ./conf/apcu.ini /usr/local/etc/php/conf.d/91-apcu.ini
 COPY ./conf/apc.ini  /usr/local/etc/php/conf.d/92-acp.ini
 
 # Enable the Apache2 modules we need
-RUN a2enmod rewrite headers expires proxy_fcgi remoteip
+RUN a2enmod rewrite headers expires proxy_fcgi remoteip && \
+    a2dismod status
 
 # Copy the openconext specific config
 COPY ./conf/openconext.conf  ./conf/security.conf  /etc/apache2/conf-enabled/

--- a/php82-apache2/Dockerfile
+++ b/php82-apache2/Dockerfile
@@ -40,8 +40,9 @@ RUN apt install -y \
   apt autoclean && \
   rm -rf /var/lib/apt/lists/*
 
-# Enable the Apache2 modules we need
-RUN a2enmod rewrite headers expires proxy_fcgi remoteip
+# Enable the Apache2 modules we need and disable the ones we don't need
+RUN a2enmod rewrite headers expires proxy_fcgi remoteip && \
+    a2dismod status
 # Copy the openconext specific config
 COPY ./conf/openconext.conf  ./conf/security.conf  /etc/apache2/conf-enabled/
 COPY ./conf/php.ini ./conf/php-cli.ini /usr/local/etc/php/


### PR DESCRIPTION
Was already removed from the apache2 container. The php containers are based on the official php containers. 