### PR TITLE
Fix Arm64 builds

### DIFF
--- a/.github/workflows/build-apache2-shibboleth.yaml
+++ b/.github/workflows/build-apache2-shibboleth.yaml
@@ -28,14 +28,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Cache Docker layers
-        uses: actions/cache@v4
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
-
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -52,13 +44,5 @@ jobs:
           tags: |
             ghcr.io/openconext/openconext-basecontainers/apache2-shibboleth:latest
             ghcr.io/openconext/openconext-basecontainers/apache2-shibboleth:${{ github.sha }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
-
-      - # Temp fix
-        # https://github.com/docker/build-push-action/issues/252
-        # https://github.com/moby/buildkit/issues/1896
-        name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+          cache-from: type=gha
+          cache-to: type=gha

--- a/.github/workflows/build-apache2-shibboleth.yaml
+++ b/.github/workflows/build-apache2-shibboleth.yaml
@@ -3,8 +3,6 @@ name: Build the Apache2 and Shibboleth container
 
 on:
   push:
-    branches:
-      - main
     paths:
       - "apache2-shibboleth/**"
       - ".github/workflows/build-apache2-shibboleth.yaml"
@@ -40,7 +38,8 @@ jobs:
         with:
           context: ./apache2-shibboleth
           platforms: linux/amd64,linux/arm64
-          push: true
+          # only push the latest tag on the main branch
+          push: "${{ github.ref == 'refs/heads/main' }}"
           tags: |
             ghcr.io/openconext/openconext-basecontainers/apache2-shibboleth:latest
             ghcr.io/openconext/openconext-basecontainers/apache2-shibboleth:${{ github.sha }}

--- a/.github/workflows/build-apache2.yaml
+++ b/.github/workflows/build-apache2.yaml
@@ -3,8 +3,6 @@ name: Build the Apache2 container
 
 on:
   push:
-    branches:
-      - main
     paths:
       - apache2/**
   schedule:
@@ -39,7 +37,8 @@ jobs:
         with:
           context: ./apache2
           platforms: linux/amd64,linux/arm64
-          push: true
+          # only push the latest tag on the main branch
+          push: "${{ github.ref == 'refs/heads/main' }}"
           tags: |
             ghcr.io/openconext/openconext-basecontainers/apache2:latest
             ghcr.io/openconext/openconext-basecontainers/apache2:${{ github.sha }}

--- a/.github/workflows/build-apache2.yaml
+++ b/.github/workflows/build-apache2.yaml
@@ -4,7 +4,8 @@ name: Build the Apache2 container
 on:
   push:
     paths:
-      - apache2/**
+      - "apache2/**"
+      - ".github/workflows/build-apache2.yaml"
   schedule:
     - cron: '0 7 * * *'
   workflow_dispatch:

--- a/.github/workflows/build-apache2.yaml
+++ b/.github/workflows/build-apache2.yaml
@@ -27,14 +27,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Cache Docker layers
-        uses: actions/cache@v4
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
-
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -51,13 +43,5 @@ jobs:
           tags: |
             ghcr.io/openconext/openconext-basecontainers/apache2:latest
             ghcr.io/openconext/openconext-basecontainers/apache2:${{ github.sha }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
-
-      - # Temp fix
-        # https://github.com/docker/build-push-action/issues/252
-        # https://github.com/moby/buildkit/issues/1896
-        name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+          cache-from: type=gha
+          cache-to: type=gha

--- a/.github/workflows/build-haproxy28.yaml
+++ b/.github/workflows/build-haproxy28.yaml
@@ -55,3 +55,5 @@ jobs:
           tags: |
             ghcr.io/openconext/openconext-basecontainers/haproxy28:latest
             ghcr.io/openconext/openconext-basecontainers/haproxy28:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha

--- a/.github/workflows/build-haproxy28.yaml
+++ b/.github/workflows/build-haproxy28.yaml
@@ -3,8 +3,6 @@ name: Build the Haproxy container
 
 on:
   push:
-    branches:
-      - "main"
     paths:
       - "haproxy28/**"
       - ".github/workflows/build-haproxy28.yaml"
@@ -51,7 +49,8 @@ jobs:
         with:
           context: ./haproxy28
           platforms: linux/amd64,linux/arm64
-          push: true
+          # only push the latest tag on the main branch
+          push: "${{ github.ref == 'refs/heads/main' }}"
           tags: |
             ghcr.io/openconext/openconext-basecontainers/haproxy28:latest
             ghcr.io/openconext/openconext-basecontainers/haproxy28:${{ github.sha }}

--- a/.github/workflows/build-php72-apache2-node14-composer2.yaml
+++ b/.github/workflows/build-php72-apache2-node14-composer2.yaml
@@ -3,8 +3,6 @@ name: Build the PHP 7.2 Apache2 Node14 Composer2 container
 
 on:
   push:
-    branches:
-      - main
     paths:
       - "php72-apache2-node14-composer2/**"
       - ".github/workflows/build-php72-apache2-node14-composer2.yaml"
@@ -39,7 +37,8 @@ jobs:
         with:
           context: ./php72-apache2-node14-composer2
           platforms: linux/amd64,linux/arm64
-          push: true
+          # only push the latest tag on the main branch
+          push: "${{ github.ref == 'refs/heads/main' }}"
           tags: |
             ghcr.io/openconext/openconext-basecontainers/php72-apache2-node14-composer2:latest
             ghcr.io/openconext/openconext-basecontainers/php72-apache2-node14-composer2:${{ github.sha }}

--- a/.github/workflows/build-php72-apache2-node14-composer2.yaml
+++ b/.github/workflows/build-php72-apache2-node14-composer2.yaml
@@ -46,7 +46,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: ./php72-apache2-node14-composer2
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ghcr.io/openconext/openconext-basecontainers/php72-apache2-node14-composer2:latest

--- a/.github/workflows/build-php72-apache2-node14-composer2.yaml
+++ b/.github/workflows/build-php72-apache2-node14-composer2.yaml
@@ -27,14 +27,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Cache Docker layers
-        uses: actions/cache@v4
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
-
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -51,13 +43,5 @@ jobs:
           tags: |
             ghcr.io/openconext/openconext-basecontainers/php72-apache2-node14-composer2:latest
             ghcr.io/openconext/openconext-basecontainers/php72-apache2-node14-composer2:${{ github.sha }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
-
-      - # Temp fix
-        # https://github.com/docker/build-push-action/issues/252
-        # https://github.com/moby/buildkit/issues/1896
-        name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+          cache-from: type=gha
+          cache-to: type=gha

--- a/.github/workflows/build-php72-apache2-node16-composer2.yaml
+++ b/.github/workflows/build-php72-apache2-node16-composer2.yaml
@@ -27,14 +27,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Cache Docker layers
-        uses: actions/cache@v4
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
-
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -51,13 +43,5 @@ jobs:
           tags: |
             ghcr.io/openconext/openconext-basecontainers/php72-apache2-node16-composer2:latest
             ghcr.io/openconext/openconext-basecontainers/php72-apache2-node16-composer2:${{ github.sha }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
-
-      - # Temp fix
-        # https://github.com/docker/build-push-action/issues/252
-        # https://github.com/moby/buildkit/issues/1896
-        name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+          cache-from: type=gha
+          cache-to: type=gha

--- a/.github/workflows/build-php72-apache2-node16-composer2.yaml
+++ b/.github/workflows/build-php72-apache2-node16-composer2.yaml
@@ -3,8 +3,6 @@ name: Build the PHP 7.2 Apache2 Node16 Composer2 container
 
 on:
   push:
-    branches:
-      - main
     paths:
       - "php72-apache2-node16-composer2/**"
       - ".github/workflows/build-php72-apache2-node16-composer2.yaml"
@@ -39,7 +37,8 @@ jobs:
         with:
           context: ./php72-apache2-node16-composer2
           platforms: linux/amd64,linux/arm64
-          push: true
+          # only push the latest tag on the main branch
+          push: "${{ github.ref == 'refs/heads/main' }}"
           tags: |
             ghcr.io/openconext/openconext-basecontainers/php72-apache2-node16-composer2:latest
             ghcr.io/openconext/openconext-basecontainers/php72-apache2-node16-composer2:${{ github.sha }}

--- a/.github/workflows/build-php72-apache2-node16-composer2.yaml
+++ b/.github/workflows/build-php72-apache2-node16-composer2.yaml
@@ -46,7 +46,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: ./php72-apache2-node16-composer2
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ghcr.io/openconext/openconext-basecontainers/php72-apache2-node16-composer2:latest

--- a/.github/workflows/build-php72-apache2.yaml
+++ b/.github/workflows/build-php72-apache2.yaml
@@ -36,7 +36,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: ./php72-apache2
-          platforms: linux/amd64,linux/arm64
+          platforms: "linux/arm64"
           # only push the latest tag on the main branch
           push: "${{ github.ref == 'refs/heads/main' }}"
           tags: |

--- a/.github/workflows/build-php72-apache2.yaml
+++ b/.github/workflows/build-php72-apache2.yaml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build-push-php72:
-    runs-on: ubuntu-latest
+    runs-on: "ubuntu-22.04"
     permissions:
       packages: write
     steps:
@@ -44,3 +44,8 @@ jobs:
             ghcr.io/openconext/openconext-basecontainers/php72-apache2:${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha
+
+      # Setup tmate session
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        if: failure()

--- a/.github/workflows/build-php72-apache2.yaml
+++ b/.github/workflows/build-php72-apache2.yaml
@@ -3,9 +3,6 @@ name: Build the PHP 7.2 Apache2 container
 
 on:
   push:
-    branches:
-      - main
-      - arm64
     paths:
       - "php72-apache2/**"
       - ".github/workflows/build-php72-apache2.yaml"
@@ -40,7 +37,8 @@ jobs:
         with:
           context: ./php72-apache2
           platforms: linux/amd64,linux/arm64
-          push: true
+          # only push the latest tag on the main branch
+          push: "${{ github.ref == 'refs/heads/main' }}"
           tags: |
             ghcr.io/openconext/openconext-basecontainers/php72-apache2:latest
             ghcr.io/openconext/openconext-basecontainers/php72-apache2:${{ github.sha }}

--- a/.github/workflows/build-php72-apache2.yaml
+++ b/.github/workflows/build-php72-apache2.yaml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - arm64
     paths:
       - "php72-apache2/**"
       - ".github/workflows/build-php72-apache2.yaml"

--- a/.github/workflows/build-php72-apache2.yaml
+++ b/.github/workflows/build-php72-apache2.yaml
@@ -21,6 +21,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -43,7 +46,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: ./php72-apache2
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ghcr.io/openconext/openconext-basecontainers/php72-apache2:latest

--- a/.github/workflows/build-php72-apache2.yaml
+++ b/.github/workflows/build-php72-apache2.yaml
@@ -28,14 +28,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Cache Docker layers
-        uses: actions/cache@v4
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
-
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -52,13 +44,5 @@ jobs:
           tags: |
             ghcr.io/openconext/openconext-basecontainers/php72-apache2:latest
             ghcr.io/openconext/openconext-basecontainers/php72-apache2:${{ github.sha }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
-
-      - # Temp fix
-        # https://github.com/docker/build-push-action/issues/252
-        # https://github.com/moby/buildkit/issues/1896
-        name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+          cache-from: type=gha
+          cache-to: type=gha

--- a/.github/workflows/build-php82-apache2-node20-composer2.yaml
+++ b/.github/workflows/build-php82-apache2-node20-composer2.yaml
@@ -27,14 +27,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Cache Docker layers
-        uses: actions/cache@v4
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
-
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -51,13 +43,5 @@ jobs:
           tags: |
             ghcr.io/openconext/openconext-basecontainers/php82-apache2-node20-composer2:latest
             ghcr.io/openconext/openconext-basecontainers/php82-apache2-node20-composer2:${{ github.sha }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
-
-      - # Temp fix
-        # https://github.com/docker/build-push-action/issues/252
-        # https://github.com/moby/buildkit/issues/1896
-        name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+          cache-from: type=gha
+          cache-to: type=gha

--- a/.github/workflows/build-php82-apache2-node20-composer2.yaml
+++ b/.github/workflows/build-php82-apache2-node20-composer2.yaml
@@ -46,7 +46,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: ./php82-apache2-node20-composer2
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ghcr.io/openconext/openconext-basecontainers/php82-apache2-node20-composer2:latest

--- a/.github/workflows/build-php82-apache2-node20-composer2.yaml
+++ b/.github/workflows/build-php82-apache2-node20-composer2.yaml
@@ -3,8 +3,6 @@ name: Build the PHP 8.2 Apache2 Node20 Composer2 container
 
 on:
   push:
-    branches:
-      - main
     paths:
       - "php82-apache2-node20-composer2/**"
       - ".github/workflows/build-php82-apache2-node20-composer2.yaml"
@@ -39,7 +37,8 @@ jobs:
         with:
           context: ./php82-apache2-node20-composer2
           platforms: linux/amd64,linux/arm64
-          push: true
+          # only push the latest tag on the main branch
+          push: "${{ github.ref == 'refs/heads/main' }}"
           tags: |
             ghcr.io/openconext/openconext-basecontainers/php82-apache2-node20-composer2:latest
             ghcr.io/openconext/openconext-basecontainers/php82-apache2-node20-composer2:${{ github.sha }}

--- a/.github/workflows/build-php82-apache2.yaml
+++ b/.github/workflows/build-php82-apache2.yaml
@@ -3,9 +3,6 @@ name: Build the PHP 8.2 Apache2 container
 
 on:
   push:
-    branches:
-      - main
-      - arm64
     paths:
       - "php82-apache2/**"
       - ".github/workflows/build-php82-apache2.yaml"
@@ -40,7 +37,8 @@ jobs:
         with:
           context: ./php82-apache2
           platforms: linux/amd64,linux/arm64
-          push: true
+          # only push the latest tag on the main branch
+          push: "${{ github.ref == 'refs/heads/main' }}"
           tags: |
             ghcr.io/openconext/openconext-basecontainers/php82-apache2:latest
             ghcr.io/openconext/openconext-basecontainers/php82-apache2:${{ github.sha }}

--- a/.github/workflows/build-php82-apache2.yaml
+++ b/.github/workflows/build-php82-apache2.yaml
@@ -21,6 +21,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -43,7 +46,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: ./php82-apache2
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ghcr.io/openconext/openconext-basecontainers/php82-apache2:latest

--- a/.github/workflows/build-php82-apache2.yaml
+++ b/.github/workflows/build-php82-apache2.yaml
@@ -28,14 +28,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Cache Docker layers
-        uses: actions/cache@v4
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
-
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -52,13 +44,5 @@ jobs:
           tags: |
             ghcr.io/openconext/openconext-basecontainers/php82-apache2:latest
             ghcr.io/openconext/openconext-basecontainers/php82-apache2:${{ github.sha }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
-
-      - # Temp fix
-        # https://github.com/docker/build-push-action/issues/252
-        # https://github.com/moby/buildkit/issues/1896
-        name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+          cache-from: type=gha
+          cache-to: type=gha

--- a/.github/workflows/build-php82-apache2.yaml
+++ b/.github/workflows/build-php82-apache2.yaml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - arm64
     paths:
       - "php82-apache2/**"
       - ".github/workflows/build-php82-apache2.yaml"

--- a/.github/workflows/build-php82-apache2.yaml
+++ b/.github/workflows/build-php82-apache2.yaml
@@ -36,7 +36,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: ./php82-apache2
-          platforms: linux/amd64,linux/arm64
+          platforms: "linux/arm64"
           # only push the latest tag on the main branch
           push: "${{ github.ref == 'refs/heads/main' }}"
           tags: |

--- a/.github/workflows/build-php82-apache2.yaml
+++ b/.github/workflows/build-php82-apache2.yaml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build-push-php82:
-    runs-on: ubuntu-latest
+    runs-on: "ubuntu-22.04"
     permissions:
       packages: write
     steps:
@@ -44,3 +44,8 @@ jobs:
             ghcr.io/openconext/openconext-basecontainers/php82-apache2:${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha
+
+      # Setup tmate session
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        if: failure()

--- a/php72-apache2/Dockerfile
+++ b/php72-apache2/Dockerfile
@@ -25,15 +25,15 @@ RUN apt install -y \
 
 # Install the PHP 7.2 extensions we need
 RUN \
-  export CC=clang-11 && \
   docker-php-ext-install -j$(nproc) \
     soap \
-    gd \
     mysqli \
     pdo_mysql \
     opcache \
     intl \
-    gmp
+    gmp  \
+    && \
+  env CC=clang-11 && docker-php-ext-install -j$(nproc) gd
 
 # Use pecl to install acpu
 RUN \

--- a/php72-apache2/Dockerfile
+++ b/php72-apache2/Dockerfile
@@ -13,6 +13,7 @@ RUN apt -y upgrade && apt -y dist-upgrade
 
 # Install the packages we need
 RUN apt install -y \
+  clang-11 \
   curl \
   libxml2 \
   libxml2-dev \
@@ -23,14 +24,16 @@ RUN apt install -y \
 
 
 # Install the PHP 7.2 extensions we need
-RUN docker-php-ext-install -j$(nproc) \
-  soap \
-  gd \
-  mysqli \
-  pdo_mysql \
-  opcache \
-  intl \
-  gmp
+RUN \
+  export CC=clang && \
+  docker-php-ext-install -j$(nproc) \
+    soap \
+    gd \
+    mysqli \
+    pdo_mysql \
+    opcache \
+    intl \
+    gmp
 
 # Use pecl to install acpu
 RUN \

--- a/php72-apache2/Dockerfile
+++ b/php72-apache2/Dockerfile
@@ -15,7 +15,6 @@ RUN chmod +x /usr/bin/composer
 RUN \
   apt-get update && \
   apt-get install -y \
-    clang-11 \
     curl \
     libxml2 \
     libxml2-dev \
@@ -23,7 +22,6 @@ RUN \
     libjpeg62-turbo-dev \
     libpng-dev \
     libgmp3-dev
-
 
 # Install the PHP 7.2 extensions we need
 RUN docker-php-ext-install soap
@@ -35,8 +33,8 @@ RUN docker-php-ext-install gmp
 RUN docker-php-ext-install -j$(nproc) intl
 RUN docker-php-ext-install -j$(nproc) gd
 
-
-RUN apt-get -y purge clang-11 libxml2-dev libfreetype6-dev libjpeg62-turbo-dev libpng-dev libgmp3-dev
+# clean up
+RUN apt-get -y purge libxml2-dev libfreetype6-dev libjpeg62-turbo-dev libpng-dev libgmp3-dev
 
 # Use pecl to install acpu
 RUN pecl install -f apcu

--- a/php72-apache2/Dockerfile
+++ b/php72-apache2/Dockerfile
@@ -8,36 +8,35 @@ COPY --from=composer:1.9.3 /usr/bin/composer /usr/bin/composer
 RUN chmod +x /usr/bin/composer
 
 # Do an initial clean up and general upgrade of the distribution
-RUN apt clean && apt autoclean && apt update
-RUN apt -y upgrade && apt -y dist-upgrade
+#RUN apt clean && apt autoclean && apt update
+#RUN apt -y upgrade && apt -y dist-upgrade
 
 # Install the packages we need
-RUN apt install -y \
-  clang-11 \
-  curl \
-  libxml2 \
-  libxml2-dev \
-  libfreetype6-dev \
-  libjpeg62-turbo-dev \
-  libpng-dev \
-  libgmp3-dev
+RUN \
+  apt-get update && \
+  apt-get install -y \
+    clang-11 \
+    curl \
+    libxml2 \
+    libxml2-dev \
+    libfreetype6-dev \
+    libjpeg62-turbo-dev \
+    libpng-dev \
+    libgmp3-dev
 
 
 # Install the PHP 7.2 extensions we need
-RUN \
-  docker-php-ext-install -j$(nproc) \
-    soap \
-    mysqli \
-    pdo_mysql \
-    opcache \
-    gmp  \
-    && \
-  env CC=clang-11 docker-php-ext-install -j$(nproc) intl && \
-  env CC=clang-11 docker-php-ext-install -j$(nproc) gd
+RUN docker-php-ext-install soap
+RUN docker-php-ext-install mysqli
+RUN docker-php-ext-install pdo_mysql
+RUN docker-php-ext-install opcache
+RUN docker-php-ext-install gmp
+
+RUN env CC=clang-11 docker-php-ext-install -j$(nproc) intl
+RUN env CC=clang-11 docker-php-ext-install -j$(nproc) gd
 
 
-RUN \
-   apt -y purge clang-11 libxml2-dev libfreetype6-dev libjpeg62-turbo-dev libpng-dev libgmp3-dev
+RUN apt -y purge clang-11 libxml2-dev libfreetype6-dev libjpeg62-turbo-dev libpng-dev libgmp3-dev
 
 # Use pecl to install acpu
 RUN \

--- a/php72-apache2/Dockerfile
+++ b/php72-apache2/Dockerfile
@@ -32,15 +32,15 @@ RUN docker-php-ext-install pdo_mysql
 RUN docker-php-ext-install opcache
 RUN docker-php-ext-install gmp
 
-RUN env CC=clang-11 docker-php-ext-install -j$(nproc) intl
-RUN env CC=clang-11 docker-php-ext-install -j$(nproc) gd
+RUN docker-php-ext-install -j$(nproc) intl
+RUN docker-php-ext-install -j$(nproc) gd
 
 
 RUN apt-get -y purge clang-11 libxml2-dev libfreetype6-dev libjpeg62-turbo-dev libpng-dev libgmp3-dev
 
 # Use pecl to install acpu
 RUN pecl install -f apcu
-RUN env CC=CLANG-11 pecl install -f apcu_bc
+RUN pecl install -f apcu_bc
 COPY ./conf/apcu.ini /usr/local/etc/php/conf.d/91-apcu.ini
 COPY ./conf/apc.ini  /usr/local/etc/php/conf.d/92-acp.ini
 

--- a/php72-apache2/Dockerfile
+++ b/php72-apache2/Dockerfile
@@ -36,12 +36,11 @@ RUN env CC=clang-11 docker-php-ext-install -j$(nproc) intl
 RUN env CC=clang-11 docker-php-ext-install -j$(nproc) gd
 
 
-RUN apt -y purge clang-11 libxml2-dev libfreetype6-dev libjpeg62-turbo-dev libpng-dev libgmp3-dev
+RUN apt-get -y purge clang-11 libxml2-dev libfreetype6-dev libjpeg62-turbo-dev libpng-dev libgmp3-dev
 
 # Use pecl to install acpu
-RUN \
-  pecl install -f apcu && \
-  pecl install -f apcu_bc
+RUN pecl install -f apcu
+RUN env CC=CLANG-11 pecl install -f apcu_bc
 COPY ./conf/apcu.ini /usr/local/etc/php/conf.d/91-apcu.ini
 COPY ./conf/apc.ini  /usr/local/etc/php/conf.d/92-acp.ini
 

--- a/php72-apache2/Dockerfile
+++ b/php72-apache2/Dockerfile
@@ -25,7 +25,7 @@ RUN apt install -y \
 
 # Install the PHP 7.2 extensions we need
 RUN \
-  export CC=clang && \
+  export CC=clang-11 && \
   docker-php-ext-install -j$(nproc) \
     soap \
     gd \

--- a/php72-apache2/Dockerfile
+++ b/php72-apache2/Dockerfile
@@ -30,10 +30,14 @@ RUN \
     mysqli \
     pdo_mysql \
     opcache \
-    intl \
     gmp  \
     && \
-  env CC=clang-11 && docker-php-ext-install -j$(nproc) gd
+  env CC=clang-11 docker-php-ext-install -j$(nproc) intl && \
+  env CC=clang-11 docker-php-ext-install -j$(nproc) gd
+
+
+RUN \
+   apt -y purge clang-11 libxml2-dev libfreetype6-dev libjpeg62-turbo-dev libpng-dev libgmp3-dev
 
 # Use pecl to install acpu
 RUN \

--- a/php82-apache2/Dockerfile
+++ b/php82-apache2/Dockerfile
@@ -14,7 +14,7 @@ RUN apt clean && apt autoclean && apt update && apt -y upgrade
 # do some compiler magic, because some packages fail to compile with gcc, others fail with clang
 RUN \
   apt install -y \
-    clang-16 \
+    gcc-11 \
     curl \
     libpng16-16 \
     libjpeg62-turbo \
@@ -33,9 +33,9 @@ RUN \
     intl \
     && \
   # opcache is a special case, it needs to be compiled with clang (or gcc will segfault)
-  env CC=clang-16 docker-php-ext-install -j$(nproc) opcache && \
+  env CC=gcc-11 docker-php-ext-install -j$(nproc) opcache && \
   apt -y remove \
-    clang-16 \
+    gcc-11 \
     libgmp-dev \
     libicu-dev \
     libfreetype6-dev \

--- a/php82-apache2/Dockerfile
+++ b/php82-apache2/Dockerfile
@@ -33,7 +33,7 @@ RUN \
     intl \
     && \
   # opcache is a special case, it needs to be compiled with clang (or gcc will segfault)
-  env CC=clang docker-php-ext-install -j$(nproc) opcache  \
+  env CC=clang-16 docker-php-ext-install -j$(nproc) opcache  \
   apt -y remove \
     clang-16 \
     libgmp-dev \

--- a/php82-apache2/Dockerfile
+++ b/php82-apache2/Dockerfile
@@ -15,8 +15,6 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN \
   apt-get update && \
   apt-get install -y \
-    gcc-9 gcc-10 \
-    clang-9 clang-11 clang-13 clang-16 \
     curl \
     libpng16-16 \
     libjpeg62-turbo \
@@ -36,7 +34,6 @@ RUN docker-php-ext-install intl
 RUN docker-php-ext-install opcache
 
 RUN apt-get -y remove \
-    gcc-9 \
     libgmp-dev \
     libicu-dev \
     libfreetype6-dev \

--- a/php82-apache2/Dockerfile
+++ b/php82-apache2/Dockerfile
@@ -24,18 +24,17 @@ RUN \
     libicu-dev \
     libfreetype6-dev \
     libjpeg62-turbo-dev \
-    libpng-dev && \
-  docker-php-ext-configure \
-    gd --with-freetype --with-jpeg && \
-  docker-php-ext-install -j$(nproc) \
-    gmp \
-    pdo_mysql \
-    gd \
-    intl \
-    && \
+    libpng-dev \
+
+RUN export CC=gcc-9 && docker-php-ext-configure gd --with-freetype --with-jpeg && docker-php-ext-install gd
+RUN echo "CC=$CC" && docker-php-ext-install gmp
+RUN docker-php-ext-install pdo_mysql
+RUN docker-php-ext-install intl
+
   # opcache is a special case, it needs to be compiled with clang (or gcc will segfault)
-  env CC=gcc-9 docker-php-ext-install -j$(nproc) opcache && \
-  apt -y remove \
+RUN env CC=gcc-9 docker-php-ext-install opcache
+
+RUN apt -y remove \
     gcc-9 \
     libgmp-dev \
     libicu-dev \

--- a/php82-apache2/Dockerfile
+++ b/php82-apache2/Dockerfile
@@ -27,13 +27,13 @@ RUN \
     libjpeg62-turbo-dev \
     libpng-dev
 
-RUN export CC=clang-16 && docker-php-ext-configure gd --with-freetype --with-jpeg && docker-php-ext-install gd
-RUN echo "CC=$CC" && docker-php-ext-install gmp
+RUN docker-php-ext-configure gd --with-freetype --with-jpeg && docker-php-ext-install gd
+RUN docker-php-ext-install gmp
 RUN docker-php-ext-install pdo_mysql
-RUN export CC=clang-16 && docker-php-ext-install intl
+RUN docker-php-ext-install intl
 
   # opcache is a special case, it needs to be compiled with clang (or gcc will segfault)
-RUN env CC=gcc-9 docker-php-ext-install opcache
+RUN docker-php-ext-install opcache
 
 RUN apt-get -y remove \
     gcc-9 \

--- a/php82-apache2/Dockerfile
+++ b/php82-apache2/Dockerfile
@@ -14,6 +14,7 @@ RUN apt clean && apt autoclean && apt update && apt -y upgrade
 # do some compiler magic, because some packages fail to compile with gcc, others fail with clang
 RUN \
   apt install -y \
+    clang-16 \
     curl \
     libpng16-16 \
     libjpeg62-turbo \
@@ -27,12 +28,14 @@ RUN \
     gd --with-freetype --with-jpeg && \
   docker-php-ext-install -j$(nproc) \
     gmp \
-    opcache  \
     pdo_mysql \
     gd \
     intl \
     && \
+  # opcache is a special case, it needs to be compiled with clang (or gcc will segfault)
+  env CC=clang docker-php-ext-install -j$(nproc) opcache  \
   apt -y remove \
+    clang-16 \
     libgmp-dev \
     libicu-dev \
     libfreetype6-dev \

--- a/php82-apache2/Dockerfile
+++ b/php82-apache2/Dockerfile
@@ -30,7 +30,7 @@ RUN \
 RUN export CC=clang-16 && docker-php-ext-configure gd --with-freetype --with-jpeg && docker-php-ext-install gd
 RUN echo "CC=$CC" && docker-php-ext-install gmp
 RUN docker-php-ext-install pdo_mysql
-RUN docker-php-ext-install intl
+RUN export CC=clang-16 && docker-php-ext-install intl
 
   # opcache is a special case, it needs to be compiled with clang (or gcc will segfault)
 RUN env CC=gcc-9 docker-php-ext-install opcache

--- a/php82-apache2/Dockerfile
+++ b/php82-apache2/Dockerfile
@@ -13,9 +13,10 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Install the packages we need
 # do some compiler magic, because some packages fail to compile with gcc, others fail with clang
 RUN \
-  apt update && \
-  apt install -y \
-    gcc-9 \
+  apt-get update && \
+  apt-get install -y \
+    gcc-9 gcc-10 \
+    clang-9 clang-11 clang-13 clang-16 \
     curl \
     libpng16-16 \
     libjpeg62-turbo \
@@ -26,7 +27,7 @@ RUN \
     libjpeg62-turbo-dev \
     libpng-dev
 
-RUN export CC=gcc-9 && docker-php-ext-configure gd --with-freetype --with-jpeg && docker-php-ext-install gd
+RUN export CC=clang-16 && docker-php-ext-configure gd --with-freetype --with-jpeg && docker-php-ext-install gd
 RUN echo "CC=$CC" && docker-php-ext-install gmp
 RUN docker-php-ext-install pdo_mysql
 RUN docker-php-ext-install intl
@@ -34,14 +35,14 @@ RUN docker-php-ext-install intl
   # opcache is a special case, it needs to be compiled with clang (or gcc will segfault)
 RUN env CC=gcc-9 docker-php-ext-install opcache
 
-RUN apt -y remove \
+RUN apt-get -y remove \
     gcc-9 \
     libgmp-dev \
     libicu-dev \
     libfreetype6-dev \
     libjpeg62-turbo-dev \
     libpng-dev && \
-  apt autoremove --purge -y && \
+  apt-get autoremove --purge -y && \
   rm -rf /var/lib/apt/lists/* /var/cache/apt
 
 # Enable the Apache2 modules we need and disable the ones we don't need

--- a/php82-apache2/Dockerfile
+++ b/php82-apache2/Dockerfile
@@ -24,7 +24,7 @@ RUN \
     libicu-dev \
     libfreetype6-dev \
     libjpeg62-turbo-dev \
-    libpng-dev \
+    libpng-dev
 
 RUN export CC=gcc-9 && docker-php-ext-configure gd --with-freetype --with-jpeg && docker-php-ext-install gd
 RUN echo "CC=$CC" && docker-php-ext-install gmp

--- a/php82-apache2/Dockerfile
+++ b/php82-apache2/Dockerfile
@@ -8,11 +8,12 @@ ENV TZ=Europe/Amsterdam
 # Do an initial clean up and general upgrade of the distribution
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt clean && apt autoclean && apt update && apt -y upgrade
+#RUN apt clean && apt autoclean && apt update && apt -y upgrade
 
 # Install the packages we need
 # do some compiler magic, because some packages fail to compile with gcc, others fail with clang
 RUN \
+  apt update && \
   apt install -y \
     gcc-9 \
     curl \
@@ -35,7 +36,7 @@ RUN \
   # opcache is a special case, it needs to be compiled with clang (or gcc will segfault)
   env CC=gcc-9 docker-php-ext-install -j$(nproc) opcache && \
   apt -y remove \
-    gcc-11 \
+    gcc-9 \
     libgmp-dev \
     libicu-dev \
     libfreetype6-dev \

--- a/php82-apache2/Dockerfile
+++ b/php82-apache2/Dockerfile
@@ -14,7 +14,7 @@ RUN apt clean && apt autoclean && apt update && apt -y upgrade
 # do some compiler magic, because some packages fail to compile with gcc, others fail with clang
 RUN \
   apt install -y \
-    gcc-11 \
+    gcc-9 \
     curl \
     libpng16-16 \
     libjpeg62-turbo \
@@ -33,7 +33,7 @@ RUN \
     intl \
     && \
   # opcache is a special case, it needs to be compiled with clang (or gcc will segfault)
-  env CC=gcc-11 docker-php-ext-install -j$(nproc) opcache && \
+  env CC=gcc-9 docker-php-ext-install -j$(nproc) opcache && \
   apt -y remove \
     gcc-11 \
     libgmp-dev \

--- a/php82-apache2/Dockerfile
+++ b/php82-apache2/Dockerfile
@@ -33,7 +33,7 @@ RUN \
     intl \
     && \
   # opcache is a special case, it needs to be compiled with clang (or gcc will segfault)
-  env CC=clang-16 docker-php-ext-install -j$(nproc) opcache  \
+  env CC=clang-16 docker-php-ext-install -j$(nproc) opcache && \
   apt -y remove \
     clang-16 \
     libgmp-dev \


### PR DESCRIPTION
- add arm64 builds (using ubuntu-22.04 runners for now, until https://github.com/actions/runner-images/issues/11471 is fixed)
- use new fancy cache feature of docker/build-push-action
- run actions for all branches, but only push for main