### PR TITLE
Switch python container to standard Debian

### DIFF
--- a/python3/Dockerfile
+++ b/python3/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/python:3.11-slim-bookworm
+FROM docker.io/library/debian:bookworm-slim
 
 # Do an initial clean up and general upgrade of the distribution
 ENV DEBIAN_FRONTEND=noninteractive
@@ -8,12 +8,15 @@ RUN \
     apt-get -y install                                   \
         build-essential                                  \
         bzip2                                            \
+        ca-certificates                                  \
         curl                                             \
         default-libmysqlclient-dev                       \
         git                                              \
         libxmlsec1-dev                                   \
         pkgconf                                          \
+        python3                                          \
         python3-dev                                      \
+        python3-venv                                     \
         util-linux                                       \
         xz-utils                                         \
         && \
@@ -24,12 +27,20 @@ RUN \
 ARG RUNAS_UID
 ARG RUNAS_GID
 
+# install default venv
+RUN \
+    python3 -m venv /venv && \
+    /venv/bin/pip install --upgrade pip wheel setuptools
+
+ENV VIRTUAL_ENV="/venv"
+ENV PATH="/venv/bin:${PATH}"
+
+# Set the default workdir
+WORKDIR /venv
+
 # Copy the startup script
 RUN mkdir /container-init /container-init-post
 COPY --chmod=0755 ./bin/entrypoint.sh /entrypoint.sh
-
-# Set the default workdir
-WORKDIR /opt
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["python3"]

--- a/python3/bin/entrypoint.sh
+++ b/python3/bin/entrypoint.sh
@@ -27,11 +27,11 @@ then
         echo "Switching to user $RUNAS_UID and group $RUNAS_GID"
         groupadd -g $RUNAS_GID openconext
         useradd -M -u $RUNAS_UID -g $RUNAS_GID openconext
-        PRIVDROP="setpriv --reuid=openconext --regid=openconext --reset-env --clear-groups"
+        PRIVDROP="runuser --user=openconext --group=openconext -- "
     else
         echo "Switching to user $RUNAS_UID"
         useradd -M -u $RUNAS_UID openconext
-        PRIVDROP="setpriv --reuid=openconext --reset-env --clear-groups"
+        PRIVDROP="runuser --user=openconext -- "
 fi
     echo "Dropping privileges to $($PRIVDROP id -u):$($PRIVDROP id -g)"
 


### PR DESCRIPTION
We already discussed a little bit if we want the basecontainers to be based on standard debian rather than upstream apache/php/python.  If we want to make the switch, this is already a fix for the (new) python container.