### PR TITLE
Build arm image on arm runner

### DIFF
--- a/.github/workflows/build-php82-apache2.yaml
+++ b/.github/workflows/build-php82-apache2.yaml
@@ -72,8 +72,7 @@ jobs:
     name: Merge images
     if: >
       github.actor!='dependabot[bot]' &&
-      github.event_name!='pull_request' &&
-
+      github.event_name!='pull_request'
     needs:
       - "build-php82"
     runs-on: "ubuntu-24.04"

--- a/.github/workflows/build-php82-apache2.yaml
+++ b/.github/workflows/build-php82-apache2.yaml
@@ -17,8 +17,9 @@ jobs:
   build-php82:
     permissions:
       packages: write
-    matrix:
-      arch: [ 'amd64', 'arm64' ]
+    strategy:
+      matrix:
+        arch: [ 'amd64', 'arm64' ]
     runs-on: |
       ubuntu-24.04${{ matrix.arch == 'arm64' && '-arm' || '' }}
     steps:

--- a/.github/workflows/build-php82-apache2.yaml
+++ b/.github/workflows/build-php82-apache2.yaml
@@ -10,21 +10,20 @@ on:
     - cron: '30 7 * * *'
   workflow_dispatch:
 
+env:
+  NAME: "php82-apache2"
+
 jobs:
-  build-push-php82:
-    runs-on: "ubuntu-22.04"
+  build-php82:
     permissions:
       packages: write
+    matrix:
+      arch: [ 'amd64', 'arm64' ]
+    runs-on: |
+      ubuntu-24.04${{ matrix.arch == 'arm64' && '-arm' || '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: "linux/amd64,linux/arm64"
-          # The latest version will lead to segmentation fault.
-          image: "tonistiigi/binfmt:qemu-v7.0.0-28"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -38,13 +37,69 @@ jobs:
 
       - name: Build and push
         uses: docker/build-push-action@v6
+        id: build
         with:
           context: ./php82-apache2
-          platforms: "linux/amd64,linux/arm64"
-          # only push the latest tag on the main branch
-          push: "${{ github.ref == 'refs/heads/main' }}"
-          tags: |
-            ghcr.io/openconext/openconext-basecontainers/php82-apache2:latest
-            ghcr.io/openconext/openconext-basecontainers/php82-apache2:${{ github.sha }}
+          platforms: "linux/${{ matrix.arch }}"
+          outputs: "type=image,push-by-digest=true,name-canonical=true,push=true"
           cache-from: type=gha
           cache-to: type=gha
+
+      - name: Export digest
+        run: |
+          mkdir -p "${{ runner.temp }}/digests/"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+          echo "Files created:"
+          find "${{ runner.temp }}/digests"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: "digests__${{ env.NAME }}__${{ matrix.arch }}"
+          path: "${{ runner.temp }}/digests/*"
+          if-no-files-found: error
+          retention-days: 1
+
+  image-php82:
+    name: Merge images
+    if: >
+      github.actor!='dependabot[bot]' &&
+      github.event_name!='pull_request' &&
+      github.ref == 'refs/heads/main'
+    needs:
+      - "build-php82"
+    runs-on: "ubuntu-24.04"
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: "${{ runner.temp }}/digests"
+          pattern: "digests__*"
+          merge-multiple: true
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: "${{ github.actor }}"
+          password: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Create manifest list and push
+        working-directory: "${{ runner.temp }}/digests/"
+        run: |
+          DIGESTS=$( printf 'ghcr.io/openconext/openconext-basecontainers/php82-apache2@sha256:%s ' * )
+          TAGS="-t latest -t ${{ github.sha }}"
+
+          echo "Creating docker manifest list"
+          echo "Digests: $DIGESTS"
+          echo "Tags: $TAGS"
+
+          docker buildx imagetools create ${TAGS} ${DIGESTS}
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ghcr.io/openconext/openconext-basecontainers/php82-apache2:latest

--- a/.github/workflows/build-php82-apache2.yaml
+++ b/.github/workflows/build-php82-apache2.yaml
@@ -41,6 +41,7 @@ jobs:
         with:
           context: ./php82-apache2
           platforms: "linux/${{ matrix.arch }}"
+          tags: "ghcr.io/openconext/openconext-basecontainers/php82-apache2"
           outputs: "type=image,push-by-digest=true,name-canonical=true,push=true"
           cache-from: type=gha
           cache-to: type=gha

--- a/.github/workflows/build-php82-apache2.yaml
+++ b/.github/workflows/build-php82-apache2.yaml
@@ -49,8 +49,8 @@ jobs:
           platforms: "linux/${{ matrix.arch }}"
           tags: "ghcr.io/openconext/openconext-basecontainers/php82-apache2"
           outputs: "type=image,push-by-digest=true,name-canonical=true,push=true"
-          cache-from: type=gha
-          cache-to: type=gha
+          cache-from: type=gha,scope=buildkit-${{ matrix.arch }}
+          cache-to: type=gha,scope=buildkit-${{ matrix.arch }}
 
       - name: Export digest
         run: |

--- a/.github/workflows/build-php82-apache2.yaml
+++ b/.github/workflows/build-php82-apache2.yaml
@@ -20,8 +20,7 @@ jobs:
     strategy:
       matrix:
         arch: [ 'amd64', 'arm64' ]
-    runs-on: |
-      ubuntu-24.04${{ matrix.arch == 'arm64' && '-arm' || '' }}
+    runs-on: "ubuntu-24.04${{ matrix.arch == 'arm64' && '-arm' || '' }}"
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build-php82-apache2.yaml
+++ b/.github/workflows/build-php82-apache2.yaml
@@ -98,7 +98,7 @@ jobs:
         working-directory: "${{ runner.temp }}/digests/"
         run: |
           DIGESTS=$( printf 'ghcr.io/openconext/openconext-basecontainers/php82-apache2@sha256:%s ' * )
-          TAGS="-t latest -t ${{ github.sha }}"
+          TAGS="-t ghcr.io/openconext/openconext-basecontainers/php82-apache2:latest -t ghcr.io/openconext/openconext-basecontainers/php82-apache2:${{ github.sha }}"
 
           echo "Creating docker manifest list"
           echo "Digests: $DIGESTS"

--- a/.github/workflows/build-php82-apache2.yaml
+++ b/.github/workflows/build-php82-apache2.yaml
@@ -13,6 +13,12 @@ on:
 env:
   NAME: "php82-apache2"
 
+# Beware of magick below!
+# The matrix strategy is used to create a job for each architecture
+# The individual images are pushed by digest to the package registry
+# The separate architectures are merged into a single image
+# see https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners
+
 jobs:
   build-php82:
     permissions:
@@ -66,8 +72,7 @@ jobs:
     name: Merge images
     if: >
       github.actor!='dependabot[bot]' &&
-      github.event_name!='pull_request' &&
-      github.ref == 'refs/heads/main'
+      github.event_name!='pull_request'
     needs:
       - "build-php82"
     runs-on: "ubuntu-24.04"

--- a/.github/workflows/build-php82-apache2.yaml
+++ b/.github/workflows/build-php82-apache2.yaml
@@ -72,7 +72,8 @@ jobs:
     name: Merge images
     if: >
       github.actor!='dependabot[bot]' &&
-      github.event_name!='pull_request'
+      github.event_name!='pull_request' &&
+
     needs:
       - "build-php82"
     runs-on: "ubuntu-24.04"
@@ -98,7 +99,10 @@ jobs:
         working-directory: "${{ runner.temp }}/digests/"
         run: |
           DIGESTS=$( printf 'ghcr.io/openconext/openconext-basecontainers/php82-apache2@sha256:%s ' * )
-          TAGS="-t ghcr.io/openconext/openconext-basecontainers/php82-apache2:latest -t ghcr.io/openconext/openconext-basecontainers/php82-apache2:${{ github.sha }}"
+          TAGS="-t ghcr.io/openconext/openconext-basecontainers/php82-apache2:${{ github.sha }}"
+          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
+              TAGS="${TAGS} -t ghcr.io/openconext/openconext-basecontainers/php82-apache2:latest"
+          fi
 
           echo "Creating docker manifest list"
           echo "Digests: $DIGESTS"

--- a/php72-apache2-node14-composer2/Dockerfile
+++ b/php72-apache2-node14-composer2/Dockerfile
@@ -1,12 +1,26 @@
 FROM ghcr.io/openconext/openconext-basecontainers/php72-apache2:latest
+
 COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
-SHELL ["/bin/bash", "--login", "-c"]
-RUN apt update && apt -y install git unzip zip vim
+
+RUN \
+    apt update && \
+    apt -y install git unzip zip vim && \
+    rm -rf /var/lib/apt/lists/* /var/cache/apt
+
 COPY --from=node:14-slim /usr/local/bin /usr/local/bin
 COPY --from=node:14-slim /opt /opt
 COPY --from=node:14-slim /usr/local/lib/node_modules /usr/local/lib/node_modules
-RUN npm install -g yarn --force
-RUN pecl install xdebug-3.1.6 && docker-php-ext-enable xdebug
+RUN npm install -g yarn --force \
+
+RUN \
+    pecl install xdebug-3.1.6 && \
+    docker-php-ext-enable xdebug
 COPY ./conf/xdebug.ini /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
-RUN rm -rf /etc/apache2/sites-enabled/* && mkdir -p /var/www/html/public
+
+RUN \
+    rm -rf /etc/apache2/sites-enabled/* && \
+    mkdir -p /var/www/html/public
+
 COPY ./conf/appconf.conf /etc/apache2/sites-enabled/
+
+SHELL ["/bin/bash", "--login", "-c"]

--- a/php72-apache2/Dockerfile
+++ b/php72-apache2/Dockerfile
@@ -7,10 +7,6 @@ ENV DEBIAN_FRONTEND=noninteractive
 COPY --from=composer:1.9.3 /usr/bin/composer /usr/bin/composer
 RUN chmod +x /usr/bin/composer
 
-# Do an initial clean up and general upgrade of the distribution
-#RUN apt clean && apt autoclean && apt update
-#RUN apt -y upgrade && apt -y dist-upgrade
-
 # Install the packages we need
 RUN \
   apt-get update && \
@@ -18,6 +14,7 @@ RUN \
     curl \
     libxml2 \
     libxml2-dev \
+    libicu-dev \
     libfreetype6-dev \
     libjpeg62-turbo-dev \
     libpng-dev \
@@ -39,29 +36,32 @@ RUN pecl install -f apcu_bc
 COPY ./conf/apcu.ini /usr/local/etc/php/conf.d/91-apcu.ini
 COPY ./conf/apc.ini  /usr/local/etc/php/conf.d/92-acp.ini
 
-# Enable the Apache2 modules we need
-RUN a2enmod rewrite headers expires proxy_fcgi remoteip && \
-    a2dismod status
+# Clean up
+# don't autoremove, becasue that will remove libraries needed for the custom-built php extensions
+RUN \
+  apt-get -y purge \
+    libxml2-dev \
+    libicu-dev \
+    libfreetype6-dev \
+    libjpeg62-turbo-dev \
+    libpng-dev \
+    libgmp-dev \
+    libgmp3-dev \
+    icu-devtools \
+    libicu-dev \
+    zlib1g-dev \
+  && \
+  rm -rf /var/lib/apt/lists/* /var/cache/apt
+
+# Enable the Apache2 modules we need and disable the ones we don't need
+RUN \
+  a2enmod rewrite headers expires proxy_fcgi remoteip \
+  && \
+  a2dismod status
 
 # Copy the openconext specific config
 COPY ./conf/openconext.conf  ./conf/security.conf  /etc/apache2/conf-enabled/
 COPY ./conf/php.ini ./conf/php-cli.ini /usr/local/etc/php/
-
-# Clean up
-# don't autoremove, becasue that will remove libraries needed for the custom-built php extensions
-# clean up
-RUN apt-get -y purge \
-    libxml2-dev \
-    libfreetype6-dev \
-    libjpeg62-turbo-dev \
-    libpng-dev \
-    libgmp3-dev \
-    icu-devtools \
-    libicu-dev \
-    libgmp-dev \
-    zlib1g-dev \
-    && \
-    rm -rf /var/lib/apt/lists/* /var/cache/apt
 
 # Copy the startup script
 COPY ./bin/entrypoint.sh /entrypoint.sh

--- a/php72-apache2/Dockerfile
+++ b/php72-apache2/Dockerfile
@@ -21,11 +21,12 @@ RUN \
     libgmp3-dev
 
 # Install the PHP 7.2 extensions we need
-RUN docker-php-ext-install soap
-RUN docker-php-ext-install mysqli
-RUN docker-php-ext-install pdo_mysql
-RUN docker-php-ext-install opcache
-RUN docker-php-ext-install gmp
+RUN docker-php-ext-install -j$(nproc) soap
+RUN docker-php-ext-install -j$(nproc) mysqli
+RUN docker-php-ext-install -j$(nproc) pdo_mysql
+RUN docker-php-ext-install -j$(nproc) opcache
+RUN docker-php-ext-install -j$(nproc) gmp
+RUN docker-php-ext-install -j$(nproc) gmp
 
 RUN docker-php-ext-install -j$(nproc) intl
 RUN docker-php-ext-install -j$(nproc) gd

--- a/php82-apache2/Dockerfile
+++ b/php82-apache2/Dockerfile
@@ -1,59 +1,63 @@
 FROM docker.io/library/php:8.2-apache-bullseye
-# Set the default workdir
-WORKDIR /var/www/html
 #Some default environment variables. They can be overridden when starting the container
 ENV PHP_MEMORY_LIMIT=128M
 ENV TZ=Europe/Amsterdam
-
-# Do an initial clean up and general upgrade of the distribution
 ENV DEBIAN_FRONTEND=noninteractive
 
-#RUN apt clean && apt autoclean && apt update && apt -y upgrade
-
 # Install the packages we need
-# do some compiler magic, because some packages fail to compile with gcc, others fail with clang
 RUN \
   apt-get update && \
   apt-get install -y \
     curl \
-    libpng16-16 \
-    libjpeg62-turbo \
-    libfreetype6 \
-    libgmp-dev \
-    libicu-dev \
-    libfreetype6-dev \
-    libjpeg62-turbo-dev \
-    libpng-dev
-
-RUN docker-php-ext-configure gd --with-freetype --with-jpeg && docker-php-ext-install gd
-RUN docker-php-ext-install gmp
-RUN docker-php-ext-install pdo_mysql
-RUN docker-php-ext-install intl
-
-RUN docker-php-ext-install opcache
-
-# don't autoremove, becasue that will remove libraries needed for the custom-built php extensions
-RUN apt-get -y remove \
-    libgmp-dev \
+    libxml2 \
+    libxml2-dev \
     libicu-dev \
     libfreetype6-dev \
     libjpeg62-turbo-dev \
     libpng-dev \
+    libgmp3-dev
+
+# Install the PHP 8.2 extensions we need
+RUN docker-php-ext-install pdo_mysql
+RUN docker-php-ext-install opcache
+RUN docker-php-ext-install gmp
+
+RUN docker-php-ext-install -j$(nproc) intl
+RUN docker-php-ext-configure gd --with-freetype --with-jpeg && docker-php-ext-install -j$(nproc) gd
+
+# Clean up
+# don't autoremove, becasue that will remove libraries needed for the custom-built php extensions
+RUN \
+  apt-get -y purge \
+    libxml2-dev \
+    libicu-dev \
+    libfreetype6-dev \
+    libjpeg62-turbo-dev \
+    libpng-dev \
+    libgmp-dev \
+    libgmp3-dev \
     icu-devtools \
     libicu-dev \
     zlib1g-dev \
- && \
+  && \
   rm -rf /var/lib/apt/lists/* /var/cache/apt
 
 # Enable the Apache2 modules we need and disable the ones we don't need
-RUN a2enmod rewrite headers expires proxy_fcgi remoteip && \
-    a2dismod status
+RUN \
+  a2enmod rewrite headers expires proxy_fcgi remoteip \
+  && \
+  a2dismod status
+
 # Copy the openconext specific config
 COPY ./conf/openconext.conf  ./conf/security.conf  /etc/apache2/conf-enabled/
 COPY ./conf/php.ini ./conf/php-cli.ini /usr/local/etc/php/
+
 # Copy the startup script
 COPY ./bin/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
+
+# Set the default workdir
+WORKDIR /var/www/html
 
 # Default port to listen on
 EXPOSE 80

--- a/php82-apache2/Dockerfile
+++ b/php82-apache2/Dockerfile
@@ -18,9 +18,9 @@ RUN \
     libgmp3-dev
 
 # Install the PHP 8.2 extensions we need
-RUN docker-php-ext-install pdo_mysql
-RUN docker-php-ext-install opcache
-RUN docker-php-ext-install gmp
+RUN docker-php-ext-install -j$(nproc) pdo_mysql
+RUN docker-php-ext-install -j$(nproc) opcache
+RUN docker-php-ext-install -j$(nproc) gmp
 
 RUN docker-php-ext-install -j$(nproc) intl
 RUN docker-php-ext-configure gd --with-freetype --with-jpeg && docker-php-ext-install -j$(nproc) gd


### PR DESCRIPTION
Use the new (experimental) arm runners to build native arm images, instead of relying on qemu emulation.  This fixes all the weird compiler errors and speeds up the build considerably.

Also clean up the php dockerfiles.